### PR TITLE
reset the IME when the user stop typing

### DIFF
--- a/apps/engine.c
+++ b/apps/engine.c
@@ -32,7 +32,7 @@ ibus_eei_engine_class_init (IBusEEIEngineClass *klass)
     engine_class->page_down = ibus_eei_engine_page_down_button;
     engine_class->page_up = ibus_eei_engine_page_up_button;
     engine_class->candidate_clicked = ibus_eei_engine_candidate_clicked;
-    engine_class->focus_out = ibus_eei_engine_focus_out;
+    engine_class->reset = ibus_eei_engine_reset;
     engine_class->enable = ibus_eei_engine_enable;
 }
 

--- a/src/predict/lib/src/lib.rs
+++ b/src/predict/lib/src/lib.rs
@@ -444,21 +444,21 @@ pub unsafe extern "C" fn ibus_eei_engine_page_up_button(engine: *mut IBusEngine)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ibus_eei_engine_focus_out(engine: *mut IBusEngine) {
+pub unsafe extern "C" fn ibus_eei_engine_reset(engine: *mut IBusEngine) {
     match EngineCore::get(engine) {
         Some(engine_core) => {
             engine_core.abort_table_input();
-            match (*engine_core.parent_engine_class).focus_out {
-                Some(parent_focus_out) => {
-                    parent_focus_out(engine);
+            match (*engine_core.parent_engine_class).reset {
+                Some(parent_reset) => {
+                    parent_reset(engine);
                 }
                 None => {
-                    log::error!("Could not retrieve parent function for focus out")
+                    log::error!("Could not retrieve parent function for reset")
                 }
             }
         }
         None => {
-            log::error!("Could not retrieve engine core for focus out");
+            log::error!("Could not retrieve engine core for reset");
         }
     }
 }


### PR DESCRIPTION
### Related issues
- resolve #17 

### Before
[Screencast from 2024-10-16 07-36-41.webm](https://github.com/user-attachments/assets/103a5a9a-42ce-4652-8a04-8bca7cfa3a38)

### Now
[Screencast from 2024-10-16 07-38-00.webm](https://github.com/user-attachments/assets/6faa5793-cf6e-4970-8c7e-f209a34e48fb)

### Change
- Used the `reset` signal to be able to reset the IME when the user stop typing.